### PR TITLE
Clean up natspec

### DIFF
--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -16,7 +16,7 @@ contract DAO is IDAO, ModuleBase {
         address[] calldata targets,
         uint256[] calldata values,
         bytes[] calldata calldatas
-    ) public authorized {
+    ) external authorized {
         if (
             targets.length != values.length ||
             targets.length != calldatas.length

--- a/contracts/ModuleBase.sol
+++ b/contracts/ModuleBase.sol
@@ -46,7 +46,7 @@ abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
         __UUPSUpgradeable_init();
     }
 
-    /// @dev Applies authorized modifier so that an upgrade require the caller to have the correct role
+    /// @notice Applies authorized modifier so that an upgrade require the caller to have the correct role
     /// @param newImplementation The address of the new implementation contract being upgraded to
     function _authorizeUpgrade(address newImplementation)
         internal


### PR DESCRIPTION
- Cleans up the natspec in the Access control contract
- Makes several public function external and re-orders them